### PR TITLE
add sufis base for downloaded images

### DIFF
--- a/cloud/.terraform.lock.hcl
+++ b/cloud/.terraform.lock.hcl
@@ -21,20 +21,3 @@ provider "registry.terraform.io/dmacvicar/libvirt" {
     "zh:d4188a343ff32c0e03ff28c7e84abce0f43cad2fdbcd9046eaafc247429039ff",
   ]
 }
-
-provider "registry.terraform.io/hashicorp/template" {
-  version = "2.2.0"
-  hashes = [
-    "h1:94qn780bi1qjrbC3uQtjJh3Wkfwd5+tTtJHOb7KTg9w=",
-    "zh:01702196f0a0492ec07917db7aaa595843d8f171dc195f4c988d2ffca2a06386",
-    "zh:09aae3da826ba3d7df69efeb25d146a1de0d03e951d35019a0f80e4f58c89b53",
-    "zh:09ba83c0625b6fe0a954da6fbd0c355ac0b7f07f86c91a2a97849140fea49603",
-    "zh:0e3a6c8e16f17f19010accd0844187d524580d9fdb0731f675ffcf4afba03d16",
-    "zh:45f2c594b6f2f34ea663704cc72048b212fe7d16fb4cfd959365fa997228a776",
-    "zh:77ea3e5a0446784d77114b5e851c970a3dde1e08fa6de38210b8385d7605d451",
-    "zh:8a154388f3708e3df5a69122a23bdfaf760a523788a5081976b3d5616f7d30ae",
-    "zh:992843002f2db5a11e626b3fc23dc0c87ad3729b3b3cff08e32ffb3df97edbde",
-    "zh:ad906f4cebd3ec5e43d5cd6dc8f4c5c9cc3b33d2243c89c5fc18f97f7277b51d",
-    "zh:c979425ddb256511137ecd093e23283234da0154b7fa8b21c2687182d9aea8b2",
-  ]
-}

--- a/cloud/main.tf
+++ b/cloud/main.tf
@@ -17,7 +17,7 @@ variable "vm_name" {
 
 variable "vm_image_source"{
   type = string
-  default = "/var/lib/libvirt/images/ubuntu-2204.qcow2"
+  default = "/var/lib/libvirt/images/ubuntu-2204.qcow2.base"
 }
 
 variable "vm_vcpu" {

--- a/scripts/get-iso.sh
+++ b/scripts/get-iso.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 IMAGE_URL="https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img"
-IMAGE_NAME="ubuntu-2204.qcow2"
+IMAGE_NAME="ubuntu-2204.qcow2.base"
 TARGET_DIR="/var/lib/libvirt/images"
 TARGET_PATH="$TARGET_DIR/$IMAGE_NAME"
 


### PR DESCRIPTION
Fix small problem but quite annoying, that for each emergency executing clear-all was also deleted downloaded images.