### PR TITLE
update installation tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,12 @@ terraform.rc
 .idea
 *.qv-info
 
+# quick-virt install/update-check state (only relevant in an installed prefix;
+# guards against a clone getting dirtied by 'task self:check-update')
+.version
+.update-cache
+.update-notified
+
 # VM shared data files (created by VMs at runtime)
 vmdata/*.txt
 **/vmdata/*.txt

--- a/README.md
+++ b/README.md
@@ -45,12 +45,33 @@ The installer places:
 | `~/.local/share/quick-virt/` | `Taskfile.yml` + `scripts/` + `modules/quick-kvm-network-reader/scripts/` |
 | `~/.local/bin/quick-virt` | Wrapper that runs `task -t ~/.local/share/quick-virt/Taskfile.yml "$@"` |
 
-**Prerequisites:** `curl`, `tar`, and [Task](https://taskfile.dev). The installer will warn if `task` isn't on your PATH.
+### Prerequisite — install Task
+
+`quick-virt` is a thin wrapper around the [**Task**](https://taskfile.dev) runner (`go-task`), so you must install `task` first — without it the CLI won't run.
+
+```bash
+# Install into ~/.local/bin (make sure it's on your PATH):
+sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b ~/.local/bin
+```
+
+Other install methods (Homebrew, Snap, apt/dnf packages, Go, etc.) are documented at the official page:
+
+- **Installation guide:** https://taskfile.dev/installation/
+- **Project site:** https://taskfile.dev
+
+Verify it's available:
+
+```bash
+task --version
+```
+
+Other prerequisites: `curl` and `tar` (used by `install.sh`). The installer also warns if `task` isn't on your PATH.
 
 **Usage:**
 
 ```bash
-quick-virt --list                          # list all available tasks
+quick-virt                                 # grouped help with examples (same as: quick-virt help)
+quick-virt --list                          # full, flat list of all tasks
 quick-virt setup:install-kvm               # install KVM + libvirt
 quick-virt setup:install-nfs-server        # install NFS server
 quick-virt images:download:ubuntu22        # download Ubuntu 22.04 cloud image
@@ -63,6 +84,20 @@ quick-virt self:version       # show installed version
 quick-virt self:update        # re-install the latest tag
 quick-virt self:uninstall     # remove
 ```
+
+**How to update:**
+
+> [!TIP]
+> `self:update` re-runs the installer and overwrites the Taskfile, scripts, and the `quick-virt` wrapper in place. Your VMs, networks, images, and Terraform projects are untouched.
+
+| Goal | Command |
+|------|---------|
+| 🟢 Update to the **latest tag** | `quick-virt self:update` |
+| 📌 Update to a **specific version** | `QV_VERSION=v0.1.8 quick-virt self:update` |
+| 🧪 Track the **development head** | `QV_VERSION=main quick-virt self:update` |
+| 🔁 Update **without the CLI** | Re-run the installer from the *Quick Install* section above |
+
+Check the result with `quick-virt self:version`.
 
 The full ordered task reference is in [`doc/SETUP.md`](./doc/SETUP.md).
 
@@ -92,6 +127,7 @@ See [`doc/MODULES.md`](./doc/MODULES.md) for module descriptions, built-in OS pr
 
 ## Documentation
 
+- [`doc/QUICK-VIRT.md`](./doc/QUICK-VIRT.md) — full `quick-virt` command reference, every command with examples
 - [`doc/SETUP.md`](./doc/SETUP.md) — Task runner installation, available tasks, and helper scripts
 - [`doc/MODULES.md`](./doc/MODULES.md) — modules, built-in OS profiles, and example walkthroughs
 - [`doc/USAGE.md`](./doc/USAGE.md) — Terraform-style module reference and feature deep dives (shared folders, OS profiles, etc.)

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -5,6 +5,20 @@ vars:
 
 tasks:
   # ---------------------------------------------------------------------------
+  # Help — grouped quick reference (shown for bare `quick-virt` / `task`)
+  # ---------------------------------------------------------------------------
+  default:
+    desc: Show grouped help with examples
+    silent: true
+    cmds:
+      - task: help
+
+  help:
+    desc: Grouped quick reference with examples (more readable than --list)
+    silent: true
+    cmd: bash "{{.TASKFILE_DIR}}/scripts/tools/help.sh"
+
+  # ---------------------------------------------------------------------------
   # Self-management (for users who installed via install.sh)
   # ---------------------------------------------------------------------------
   self:version:
@@ -32,15 +46,21 @@ tasks:
         echo "version  : unknown (running from a cloned repo, not an install)"
       fi
 
+  self:check-update:
+    desc: Check GitHub for a newer quick-virt version and report installed vs latest
+    cmd: bash "{{.TASKFILE_DIR}}/scripts/tools/check-update.sh" status
+
   self:update:
     desc: Re-install the latest tag (or override with QV_VERSION=<tag>)
     cmd: curl -fsSL https://raw.githubusercontent.com/mironx/quick-virt/main/install.sh | bash
 
   self:uninstall:
-    desc: Remove the quick-virt installation (~/.local/share/quick-virt and ~/.local/bin/quick-virt)
+    desc: Remove the quick-virt installation (prefix from this Taskfile + the quick-virt wrapper)
     cmd: |
-      rm -rf "$HOME/.local/share/quick-virt" "$HOME/.local/bin/quick-virt"
-      echo "[ok] quick-virt uninstalled"
+      prefix="{{.TASKFILE_DIR}}"
+      bin="$(command -v quick-virt 2>/dev/null || echo "$HOME/.local/bin/quick-virt")"
+      rm -rf "$prefix" "$bin"
+      echo "[ok] quick-virt uninstalled (removed $prefix and $bin)"
 
   # ---------------------------------------------------------------------------
   # Setup
@@ -106,8 +126,10 @@ tasks:
       vars: [PHYS_IF, BRIDGE_NAME]
 
   bridge:restore:
-    desc: Restore network after bridge removal
-    cmd: sudo {{.SCRIPTS_DIR}}/linux-bridge/restore-network.sh
+    desc: Restore network after bridge removal (requires PHYS_IF and BRIDGE_NAME)
+    cmd: sudo {{.SCRIPTS_DIR}}/linux-bridge/restore-network.sh --phys-if {{.PHYS_IF}} --bridge-name {{.BRIDGE_NAME}}
+    requires:
+      vars: [PHYS_IF, BRIDGE_NAME]
 
   # ---------------------------------------------------------------------------
   # Tools
@@ -191,4 +213,4 @@ tasks:
 
   net:test:
     desc: Run tests for kvm-net-info.sh
-    cmd: ./modules/quick-kvm-network-reader/scripts/test-kvm-net-info.sh
+    cmd: '{{.SCRIPTS_DIR}}/../modules/quick-kvm-network-reader/scripts/test-kvm-net-info.sh'

--- a/doc/QUICK-VIRT.md
+++ b/doc/QUICK-VIRT.md
@@ -1,0 +1,323 @@
+# `quick-virt` — Command Reference
+
+Complete reference for every `quick-virt` command, with at least one example each.
+
+`quick-virt` is a thin wrapper around the [Task](https://taskfile.dev) runner — every command maps to a task in `Taskfile.yml`, which in turn calls a script under `scripts/`.
+
+- **Installed via `install.sh`:** use `quick-virt <command>` from anywhere.
+- **From a cloned repo:** use `task <command>` from the repo root. The two are interchangeable; this page uses the `quick-virt` form.
+
+```bash
+quick-virt help        # grouped quick reference with examples (or just: quick-virt)
+quick-virt --list      # full, flat list of every command with its description
+quick-virt <group>:<action> [VAR=value ...]
+```
+
+`quick-virt help` (also shown when you run `quick-virt` with no arguments) prints a colored, grouped cheat-sheet — the same commands as this page, condensed. This document is the long-form reference.
+
+Several commands run privileged steps (package install, network, libvirt) and call `sudo` internally — you'll be prompted for your password even though you don't type `sudo` yourself.
+
+**Table of contents**
+
+- [Self-management (`self:*`)](#self-management)
+- [Host setup (`setup:*`)](#host-setup)
+- [OS images (`images:*`)](#os-images)
+- [Linux bridge (`bridge:*`)](#linux-bridge)
+- [KVM network info (`net:*`)](#kvm-network-info)
+- [Scaffolding (`scaffold:*`)](#scaffolding)
+- [Cleanup tools (`tools:*`)](#cleanup-tools)
+- [Parameter reference](#parameter-reference)
+
+---
+
+## Self-management
+
+Manage the `quick-virt` installation itself (only meaningful when installed via `install.sh`).
+
+> [!NOTE]
+> **Automatic update check.** Every `quick-virt` command (except `self:*`) prints a one-line notice on stderr when a newer release exists — e.g. `[quick-virt] Update available: v0.1.0 → v0.2.4. Run: quick-virt self:update`. It is offline-instant (it reads a cache refreshed in the background at most once per 24h) and never delays or blocks your command. Clone users (running `task` directly) don't get this notice — use `self:check-update` instead.
+
+Environment variables that tune or disable the automatic check:
+
+| Env var | Effect |
+|---------|--------|
+| `QV_NO_UPDATE_CHECK=1` | Disable the notice entirely |
+| `QV_UPDATE_TTL=<sec>` | Seconds between background GitHub checks (default `86400`) |
+| `QV_NAG_TTL=<sec>` | Seconds between repeated notices (default `86400`) |
+
+### `self:version`
+Show the installed version (reads `.version`). Prints `unknown` when run from a cloned repo.
+```bash
+quick-virt self:version
+# v0.1.8
+```
+
+### `self:check-update`
+Explicitly query GitHub and report installed vs latest (synchronous; also refreshes the cache). This is the manual equivalent of the automatic notice — and the only way clone users get it.
+```bash
+quick-virt self:check-update
+# installed: v0.1.0
+# latest   : v0.2.4
+# [update] newer version available — run: quick-virt self:update
+```
+
+### `self:where`
+Show where `quick-virt` lives: prefix, Taskfile path, wrapper binary, and version.
+```bash
+quick-virt self:where
+# prefix   : /home/devx/.local/share/quick-virt
+# taskfile : /home/devx/.local/share/quick-virt/Taskfile.yml
+# binary   : /home/devx/.local/bin/quick-virt
+# version  : v0.1.8
+```
+
+### `self:update`
+Re-run the installer to fetch the latest tag. Override the version with `QV_VERSION`.
+```bash
+quick-virt self:update
+QV_VERSION=v0.1.8 quick-virt self:update   # pin a specific tag
+QV_VERSION=main   quick-virt self:update   # track development head
+```
+
+> [!TIP]
+> Updating overwrites the Taskfile, scripts, and the `quick-virt` wrapper in place. Your VMs, networks, images, and Terraform projects are untouched. Confirm afterwards with `quick-virt self:version`.
+
+| Goal | Command |
+|------|---------|
+| 🟢 Update to the **latest tag** | `quick-virt self:update` |
+| 📌 Update to a **specific version** | `QV_VERSION=v0.1.8 quick-virt self:update` |
+| 🧪 Track the **development head** | `QV_VERSION=main quick-virt self:update` |
+| 🔁 Update **without the CLI** | Re-run `install.sh` (see [README → Quick Install](../README.md#quick-install-no-clone-required)) |
+
+### `self:uninstall`
+Remove the installation (the install prefix + the `quick-virt` wrapper).
+```bash
+quick-virt self:uninstall
+# [ok] quick-virt uninstalled (removed /home/devx/.local/share/quick-virt and /home/devx/.local/bin/quick-virt)
+```
+
+---
+
+## Host setup
+
+One-time host preparation: KVM/libvirt, shared folders, and NFS.
+
+### `setup:install-kvm`
+Install KVM, libvirt, and related packages. Run once on a fresh host before anything else.
+```bash
+quick-virt setup:install-kvm
+```
+
+### `setup:install-virtiofsd`
+Install the `virtiofsd` daemon (needed for `fs_type = "virtiofs"` shared folders — the recommended driver).
+```bash
+quick-virt setup:install-virtiofsd
+```
+
+### `setup:check-shared-folders-drivers`
+Check `virtiofs` and `9p` driver availability on the host (read-only diagnostics).
+```bash
+quick-virt setup:check-shared-folders-drivers
+```
+
+### `setup:enable-shared-folders`
+Add `libvirt-qemu` to **your** user's group so QEMU can read your files (required before mounting host dirs into VMs). Restart libvirtd afterwards.
+```bash
+quick-virt setup:enable-shared-folders
+sudo systemctl restart libvirtd
+```
+
+### `setup:disable-shared-folders`
+Rollback of the above — remove `libvirt-qemu` from your group.
+```bash
+quick-virt setup:disable-shared-folders
+```
+
+### `setup:enable-shared-folders-for` — requires `USER`
+Same as `enable-shared-folders` but for a specific user account.
+```bash
+quick-virt setup:enable-shared-folders-for USER=devx
+```
+
+### `setup:disable-shared-folders-for` — requires `USER`
+Rollback for a specific user.
+```bash
+quick-virt setup:disable-shared-folders-for USER=devx
+```
+
+### `setup:install-nfs-server`
+Install and enable the NFS server (`nfs-kernel-server` on Debian/Ubuntu, `nfs-utils` on Rocky). Required once before using VMs with `nfs_mounts`.
+```bash
+quick-virt setup:install-nfs-server
+```
+
+### `setup:configure-nfs-export` — requires `DIR`, `CIDR`
+Create the directory, set ownership, and add an idempotent `/etc/exports` entry. Optional `OPTIONS` and `OWNER`.
+```bash
+# Minimal — defaults: OPTIONS=rw,sync,no_subtree_check,no_root_squash, OWNER=caller's user:group
+quick-virt setup:configure-nfs-export DIR=/home/devx/vm-shares CIDR=192.168.100.0/24
+
+# Read-only export, explicit owner
+quick-virt setup:configure-nfs-export \
+  DIR=/home/devx/vm-shares \
+  CIDR=192.168.100.0/24 \
+  OPTIONS=ro,sync,no_subtree_check \
+  OWNER=devx:devx
+```
+`DIR` must be an absolute path. Re-running for the same `DIR` replaces the existing entry.
+
+---
+
+## OS images
+
+Download / list / remove cloud images into `/var/lib/libvirt/images`. Supported: `ubuntu_22`, `ubuntu_24`, `rocky_9`, `debian_12`.
+
+### `images:list`
+List all supported images and their download status (with size).
+```bash
+quick-virt images:list
+```
+
+### `images:download:all`
+Download every supported cloud image.
+```bash
+quick-virt images:download:all
+```
+
+### `images:download:ubuntu22` · `:ubuntu24` · `:rocky9` · `:debian12`
+Download a single image. Run before provisioning a VM with the matching `os_name` in local mode.
+```bash
+quick-virt images:download:ubuntu22    # Ubuntu 22.04
+quick-virt images:download:ubuntu24    # Ubuntu 24.04
+quick-virt images:download:rocky9      # Rocky Linux 9
+quick-virt images:download:debian12    # Debian 12
+```
+
+### `images:remove:all`
+Remove all downloaded images (clear the local cache).
+```bash
+quick-virt images:remove:all
+```
+
+### `images:remove:ubuntu22` · `:ubuntu24` · `:rocky9` · `:debian12`
+Remove a single image (e.g. to force a re-download or free disk space).
+```bash
+quick-virt images:remove:ubuntu22
+quick-virt images:remove:ubuntu24
+quick-virt images:remove:rocky9
+quick-virt images:remove:debian12
+```
+
+---
+
+## Linux bridge
+
+Only needed for **bridge-mode** networks. Uses NetworkManager (`nmcli`). These commands modify host networking and may briefly drop connectivity — be careful on remote hosts.
+
+### `bridge:status`
+Show status and recommendations for all bridges, or a single one via `BRIDGE`.
+```bash
+quick-virt bridge:status              # all bridges
+quick-virt bridge:status BRIDGE=br0   # one bridge
+```
+
+### `bridge:create` — requires `PHYS_IF`, `BRIDGE_NAME`
+Create a bridge tied to a physical interface (clones its MAC, attaches it as slave, DHCP IPv4). Run once before using bridge-mode networks.
+```bash
+quick-virt bridge:create PHYS_IF=enp0s31f6 BRIDGE_NAME=br0
+```
+Find your interface name with `ip -br link`.
+
+### `bridge:restore` — requires `PHYS_IF`, `BRIDGE_NAME`
+Tear down the bridge and its slave, then recreate a plain DHCP connection on the physical interface. Recovery path if a bridge broke connectivity.
+```bash
+quick-virt bridge:restore PHYS_IF=enp0s31f6 BRIDGE_NAME=br0
+```
+
+---
+
+## KVM network info
+
+### `net:info` — requires `NET`
+Print the resolved parameters (CIDR, gateway, DHCP range, …) of an existing libvirt network.
+```bash
+quick-virt net:info NET=qvexample-neta-loc-1
+```
+
+### `net:test`
+Run the smoke tests for the `kvm-net-info.sh` reader. Useful after changing the `quick-kvm-network-reader` module.
+```bash
+quick-virt net:test
+```
+
+---
+
+## Scaffolding
+
+Bootstrap boilerplate configs into a target directory.
+
+### `scaffold:init-cloud-config` — requires `DIR`
+Create a cloud-init `user-data.tmpl`, auto-injecting your SSH public key from `~/.ssh/` (placeholder if none found). Skips if the file already exists.
+```bash
+quick-virt scaffold:init-cloud-config DIR=./templates
+quick-virt scaffold:init-cloud-config DIR=.            # current directory
+```
+Output: `<DIR>/user-data.tmpl`.
+
+### `scaffold:init-networks` — optional `DIR`, `REF`
+Scaffold a Terraform project (`main.tf`, `variables.tf`, `networks.auto.tfvars`) for KVM networks via the `quick-networks` module. `DIR` defaults to `.`; `REF` (module git ref) defaults to the installed version, else `main`. Existing files are not overwritten.
+```bash
+quick-virt scaffold:init-networks                       # into current dir, installed version
+quick-virt scaffold:init-networks DIR=./my-networks     # into a subdir
+quick-virt scaffold:init-networks DIR=./my-networks REF=v0.1.8   # pin module ref
+
+# Then:
+cd ./my-networks
+terraform init
+terraform apply
+```
+
+---
+
+## Cleanup tools
+
+Emergency cleanup when Terraform state can't recover. **Destructive — affects every VM / network on the host.**
+
+### `tools:clean-vms`
+Destroy and undefine **all** libvirt VMs.
+```bash
+quick-virt tools:clean-vms
+```
+
+### `tools:clean-networks`
+Destroy **all** libvirt/KVM networks.
+```bash
+quick-virt tools:clean-networks
+```
+
+---
+
+## Parameter reference
+
+Variables are passed as `NAME=value` after the command (Task syntax).
+
+| Command | Required | Optional | Notes |
+|---------|----------|----------|-------|
+| `setup:enable-shared-folders-for` | `USER` | — | target username |
+| `setup:disable-shared-folders-for` | `USER` | — | target username |
+| `setup:configure-nfs-export` | `DIR`, `CIDR` | `OPTIONS`, `OWNER` | `DIR` absolute; defaults: `OPTIONS=rw,sync,no_subtree_check,no_root_squash`, `OWNER=` caller's `user:group` |
+| `bridge:status` | — | `BRIDGE` | omit `BRIDGE` for all bridges |
+| `bridge:create` | `PHYS_IF`, `BRIDGE_NAME` | — | physical iface + bridge name |
+| `bridge:restore` | `PHYS_IF`, `BRIDGE_NAME` | — | physical iface + bridge name |
+| `net:info` | `NET` | — | libvirt network name |
+| `scaffold:init-cloud-config` | `DIR` | — | output dir for `user-data.tmpl` |
+| `scaffold:init-networks` | — | `DIR`, `REF` | `DIR` default `.`; `REF` default installed version / `main` |
+
+`QV_VERSION` (environment variable, not a task var) overrides the version for `self:update`:
+```bash
+QV_VERSION=v0.1.8 quick-virt self:update
+```
+
+---
+
+See also: [`doc/SETUP.md`](./SETUP.md) for the recommended **ordered** workflow (host → images → networks → VMs → cleanup), and [`doc/USAGE.md`](./USAGE.md) for the Terraform module reference.

--- a/install.sh
+++ b/install.sh
@@ -88,6 +88,18 @@ echo "$QV_VERSION" > "$PREFIX/.version"
 
 cat > "$BIN_DIR/quick-virt" <<EOF
 #!/bin/bash
+if ! command -v task >/dev/null 2>&1; then
+    echo "[error] 'task' runner is not installed — quick-virt needs it to run." >&2
+    echo "        Install Task from: https://taskfile.dev/installation/" >&2
+    exit 1
+fi
+# Best-effort update notice: 'compare' is offline & instant; 'refresh' updates the
+# cache in the background for next time. Skipped for self:* and when QV_NO_UPDATE_CHECK is set.
+check="$PREFIX/scripts/tools/check-update.sh"
+if [ -z "\${QV_NO_UPDATE_CHECK:-}" ] && [ -f "\$check" ] && [[ "\${1:-}" != self:* ]]; then
+    bash "\$check" compare || true
+    bash "\$check" refresh >/dev/null 2>&1 &
+fi
 exec task -t "$PREFIX/Taskfile.yml" "\$@"
 EOF
 chmod +x "$BIN_DIR/quick-virt"

--- a/scripts/tools/check-update.sh
+++ b/scripts/tools/check-update.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+#
+# Script Name: check-update.sh
+#
+# Description:
+#   Best-effort "a newer version is available" notice for quick-virt. Designed to
+#   run from the quick-virt wrapper without adding latency or breaking offline use.
+#
+# Modes:
+#   compare  Offline & instant. Compares the installed .version against the cached
+#            latest tag (written by 'refresh') and warns on stderr if a newer
+#            release exists. Throttled to one notice per QV_NAG_TTL seconds.
+#   refresh  Network. Refreshes the cached latest tag from GitHub, throttled to one
+#            request per QV_UPDATE_TTL seconds. Safe to run in the background.
+#   status   Network & synchronous. Always queries GitHub and prints installed vs
+#            latest. Backs 'quick-virt self:check-update'.
+#
+# Env:
+#   QV_UPDATE_TTL  Seconds between network refreshes (default 86400 = 24h).
+#   QV_NAG_TTL     Seconds between repeated nags     (default 86400 = 24h).
+#
+# Cache files (only written for real installs, i.e. when .version exists):
+#   <prefix>/.update-cache     "<epoch> <latest_tag>"  — written by refresh/status
+#   <prefix>/.update-notified  "<epoch>"               — written by compare
+#
+
+set -euo pipefail
+
+REPO="mironx/quick-virt"
+UPDATE_TTL="${QV_UPDATE_TTL:-86400}"
+NAG_TTL="${QV_NAG_TTL:-86400}"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PREFIX="$(cd "$SCRIPT_DIR/../.." && pwd)"
+VERSION_FILE="$PREFIX/.version"
+CACHE_FILE="$PREFIX/.update-cache"
+NOTIFY_FILE="$PREFIX/.update-notified"
+
+now() { date +%s; }
+
+is_semver() { [[ "$1" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; }
+
+installed_version() {
+  [ -f "$VERSION_FILE" ] || return 1
+  tr -d '[:space:]' < "$VERSION_FILE"
+}
+
+# Latest semver tag from GitHub. Empty on failure/offline (5s timeout).
+latest_tag() {
+  curl -fsSL --max-time 5 "https://api.github.com/repos/${REPO}/tags" 2>/dev/null \
+    | grep '"name"' \
+    | sed -E 's/.*"name": "([^"]+)".*/\1/' \
+    | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+    | sort -V | tail -1
+}
+
+# is_newer A B → true if B is strictly newer than A (both semver).
+is_newer() {
+  [ "$1" != "$2" ] && [ "$(printf '%s\n%s\n' "$1" "$2" | sort -V | tail -1)" = "$2" ]
+}
+
+cmd_refresh() {
+  [ -f "$VERSION_FILE" ] || return 0          # only for real installs — keep clones clean
+  if [ -f "$CACHE_FILE" ]; then
+    local ts; ts="$(cut -d' ' -f1 "$CACHE_FILE" 2>/dev/null || echo 0)"
+    [ "$(( $(now) - ${ts:-0} ))" -lt "$UPDATE_TTL" ] && return 0
+  fi
+  local tag; tag="$(latest_tag || true)"
+  [ -n "$tag" ] || return 0
+  printf '%s %s\n' "$(now)" "$tag" > "$CACHE_FILE"
+}
+
+cmd_compare() {
+  local inst latest
+  inst="$(installed_version || true)"
+  { [ -n "$inst" ] && is_semver "$inst"; } || return 0    # skip 'main'/unknown
+  [ -f "$CACHE_FILE" ] || return 0
+  latest="$(cut -d' ' -f2 "$CACHE_FILE" 2>/dev/null || true)"
+  { [ -n "$latest" ] && is_semver "$latest"; } || return 0
+  is_newer "$inst" "$latest" || return 0
+
+  # throttle repeated nags
+  if [ -f "$NOTIFY_FILE" ]; then
+    local nts; nts="$(cut -d' ' -f1 "$NOTIFY_FILE" 2>/dev/null || echo 0)"
+    [ "$(( $(now) - ${nts:-0} ))" -lt "$NAG_TTL" ] && return 0
+  fi
+  printf '%s\n' "$(now)" > "$NOTIFY_FILE" 2>/dev/null || true
+  printf '[quick-virt] Update available: %s → %s. Run: quick-virt self:update\n' "$inst" "$latest" >&2
+}
+
+cmd_status() {
+  local inst latest
+  inst="$(installed_version || echo 'unknown')"
+  latest="$(latest_tag || true)"
+  if [ -z "$latest" ]; then
+    echo "[warn] could not reach GitHub to check for updates (offline?)" >&2
+    echo "installed: $inst"
+    return 0
+  fi
+  [ -f "$VERSION_FILE" ] && printf '%s %s\n' "$(now)" "$latest" > "$CACHE_FILE"
+  echo "installed: $inst"
+  echo "latest   : $latest"
+  if ! is_semver "$inst"; then
+    echo "[note] installed version is not a release tag — cannot compare"
+  elif [ "$inst" = "$latest" ]; then
+    echo "[ok] up to date"
+  elif is_newer "$inst" "$latest"; then
+    echo "[update] newer version available — run: quick-virt self:update"
+  else
+    echo "[ok] ahead of latest published tag"
+  fi
+}
+
+case "${1:-compare}" in
+  compare) cmd_compare ;;
+  refresh) cmd_refresh ;;
+  status)  cmd_status ;;
+  *) echo "usage: $(basename "$0") {compare|refresh|status}" >&2; exit 2 ;;
+esac

--- a/scripts/tools/help.sh
+++ b/scripts/tools/help.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+#
+# help.sh — grouped, example-driven quick reference for quick-virt.
+#   Ordered from must-have install, through configuration, to tools and self-management.
+#   More readable than `task --list`. Colors auto-disable when output isn't a TTY.
+#
+
+set -euo pipefail
+
+if [ -t 1 ]; then
+  B=$'\033[1m'; C=$'\033[36m'; D=$'\033[2m'; R=$'\033[0m'
+else
+  B=''; C=''; D=''; R=''
+fi
+
+# Use 'quick-virt' when installed on PATH, otherwise 'task' (running from a clone).
+CMD="quick-virt"
+command -v quick-virt >/dev/null 2>&1 || CMD="task"
+
+hdr() { printf '\n%s%s%s\n' "$B" "$1" "$R"; }
+row() { printf '  %s%-30s%s %s\n' "$C" "$1" "$R" "$2"; }   # bare command + description
+ex()  { printf '       %se.g. %s%s\n' "$D" "$1" "$R"; }    # dim example line
+note(){ printf '  %s%s%s\n' "$D" "$1" "$R"; }
+
+printf '%squick-virt%s — quick KVM virtual machines on Linux (Terraform + Task)\n' "$B" "$R"
+printf 'Usage: %s%s <command> [VAR=value ...]%s   ·   commands below are shown without the leading "%s"\n' \
+  "$C" "$CMD" "$R" "$CMD"
+
+hdr "First run (zero → running VM)"
+note "0. Install Task first → https://taskfile.dev/installation/"
+note "   sh -c \"\$(curl --location https://taskfile.dev/install.sh)\" -- -d -b ~/.local/bin"
+note "1. $CMD setup:install-kvm                 # KVM + libvirt (once per host)"
+note "2. $CMD images:download:ubuntu22          # an OS cloud image"
+note "3. $CMD scaffold:init-networks DIR=./net  # then: cd net && terraform init && terraform apply"
+note "4. apply a VM example (examples/example3a-vm) or use the quick-vm module"
+
+hdr "1. Host setup — must have"
+row "setup:install-kvm"                "Install KVM, libvirt and helpers (run first)"
+row "setup:install-virtiofsd"          "Install virtiofsd (for virtiofs shared folders)"
+row "setup:check-shared-folders-drivers" "Check virtiofs / 9p driver availability"
+row "setup:install-nfs-server"         "Install + enable the NFS server"
+
+hdr "2. OS images"
+row "images:list"                      "List images and download status"
+row "images:download:ubuntu22"         "Download Ubuntu 22.04"
+ex  "$CMD images:download:ubuntu24   (also :rocky9  :debian12  :all)"
+row "images:remove:ubuntu22"           "Remove one image (also :all)"
+
+hdr "3. Networks & Linux bridge"
+row "net:info NET=<name>"              "Show CIDR / gateway / DHCP of a libvirt network"
+ex  "$CMD net:info NET=qvexample-neta-loc-1"
+row "bridge:status"                    "Show bridge status (all, or BRIDGE=br0 for one)"
+row "bridge:create"                    "Create a bridge bound to a physical NIC"
+ex  "$CMD bridge:create PHYS_IF=enp0s31f6 BRIDGE_NAME=br0"
+row "bridge:restore"                   "Tear down the bridge, restore plain DHCP"
+ex  "$CMD bridge:restore PHYS_IF=enp0s31f6 BRIDGE_NAME=br0"
+
+hdr "4. Configuration — shared folders & NFS"
+row "setup:enable-shared-folders"      "Let QEMU read your files (your user)"
+row "setup:enable-shared-folders-for"  "Same, for a specific user (USER=...)"
+ex  "$CMD setup:enable-shared-folders-for USER=devx"
+row "setup:disable-shared-folders"     "Roll back shared-folder access"
+row "setup:configure-nfs-export"       "Add an NFS export (DIR, CIDR required)"
+ex  "$CMD setup:configure-nfs-export DIR=/home/you/vm-shares CIDR=192.168.100.0/24"
+
+hdr "5. Scaffolding"
+row "scaffold:init-networks"           "Scaffold a Terraform KVM-networks project"
+ex  "$CMD scaffold:init-networks DIR=./net"
+row "scaffold:init-cloud-config"       "Create a cloud-init user-data template"
+ex  "$CMD scaffold:init-cloud-config DIR=./templates"
+
+hdr "6. Tools — cleanup (destructive)"
+row "tools:clean-vms"                  "Destroy & undefine ALL libvirt VMs"
+row "tools:clean-networks"             "Destroy ALL libvirt networks"
+
+hdr "7. Manage quick-virt itself"
+row "self:version"                     "Show installed version"
+row "self:check-update"                "Check GitHub for a newer version"
+row "self:update"                      "Re-install latest (QV_VERSION=<tag> to pin)"
+row "self:where"                       "Show install paths"
+row "self:uninstall"                   "Remove the installation"
+
+hdr "More"
+row "--list"                           "Full, flat list of every task"
+note "Full reference with examples → doc/QUICK-VIRT.md"
+printf '\n'


### PR DESCRIPTION
 Improve quick-virt CLI: help command, update notices, Taskfile fixes & docs
  
  Polish of the installer-based quick-virt CLI — usability, self-update awareness, and docs.

  Changes
  - help command — grouped, colored cheat-sheet with examples (must-have install → config → tools). Shown for bare quick-virt. Backed by scripts/tools/help.sh.
  - Update notices — every command warns on stderr when a newer release exists (offline-instant, background-refreshed ≤1×/24h, opt-out via QV_NO_UPDATE_CHECK). Adds self:check-update. Backed by
  scripts/tools/check-update.sh.
  - task-not-installed guard — wrapper prints a clear error + link to taskfile.dev instead of command not found.
  - Taskfile fixes — bridge:restore now passes the required PHYS_IF/BRIDGE_NAME; net:test path works post-install; self:uninstall respects the real install prefix.
  - Docs — new doc/QUICK-VIRT.md (full command reference), README install-Task prerequisite + update section.
